### PR TITLE
Dash line pattern and font loader extensions

### DIFF
--- a/def.go
+++ b/def.go
@@ -18,6 +18,7 @@ package gofpdf
 
 import (
 	"bytes"
+	"io"
 )
 
 // Version of FPDF from which this package is derived
@@ -132,6 +133,15 @@ type InitType struct {
 	FontDirStr     string
 }
 
+// FontLoader is used to read fonts (JSON font specification and zlib compressed font binaries)
+// from arbitrary locations (e.g. files, zip files, embedded font resources).
+//
+// Open provides an io.Reader for the specified font file (.json or .z). The file name
+// does never include a path. Open returns an error if the specified file cannot be opened.
+type FontLoader interface {
+	Open(name string) (io.Reader, error)
+}
+
 // Fpdf is the principal structure for creating a single PDF document
 type Fpdf struct {
 	page             int                       // current page number
@@ -160,6 +170,7 @@ type Fpdf struct {
 	lasth            float64                   // height of last printed cell
 	lineWidth        float64                   // line width in user unit
 	fontpath         string                    // path containing fonts
+	fontLoader       FontLoader                // used to load font files from arbitrary locations
 	coreFonts        map[string]bool           // array of core font names
 	fonts            map[string]fontDefType    // array of used fonts
 	fontFiles        map[string]fontFileType   // array of font files

--- a/def.go
+++ b/def.go
@@ -195,6 +195,8 @@ type Fpdf struct {
 	fontDirStr       string                    // location of font definition files
 	capStyle         int                       // line cap style: butt 0, round 1, square 2
 	joinStyle        int                       // line segment join style: miter 0, round 1, bevel 2
+	dashArray        []float64                 // dash array
+	dashPhase        float64                   // dash phase
 	blendList        []blendModeType           // slice[idx] of alpha transparency modes, 1-based
 	blendMap         map[string]int            // map into blendList
 	gradientList     []gradientType            // slice[idx] of gradient records

--- a/util.go
+++ b/util.go
@@ -69,6 +69,19 @@ func bufferFromReader(r io.Reader) (b *bytes.Buffer, err error) {
 	return
 }
 
+// Returns true if the two specified integer slices are equal
+func slicesEqual(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // Returns a zlib-compressed copy of the specified byte array
 func sliceCompress(data []byte) []byte {
 	var buf bytes.Buffer


### PR DESCRIPTION
This pull request adds two features to the Fpdf document generator:

#### Dash line patterns
You can configure a dash pattern in the graphics state using `SetDashPattern()`. Example: 
```
// Draw a dashed line with a 0.2mm black / 0.4mm white pattern. 
// Dash patterns are explained on page 217 of the Adobe PDF Reference 1.7: 
// http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_reference_1-7.pdf 
pdf.SetDashPattern([]float64{0.2, 0.4}, 0) 
pdf.Line(10, 10, 200, 10) 
```

#### Load fonts from non-file sources
With `SetFontLoader()` you can add a font loader that is used whenever Fpdf needs to load a .json or .z font file. The font loader is supposed to return an `io.Reader` for the requested file. If it returns an error instead Fpdf tries to load the font file from the specified font folder (`SetFontLocation()`).
 
Example:
```
type fontLoader struct{}

func (fl fontLoader) Open(name string) (io.Reader, error) {
    // In this example "fs" is a Go http.FileSystem that might be accessing
    // resources embedded into a Go binary. Or it might load fonts from a Zip file.
	return fs.Open("fonts/" + name)
}

pdf := gofpdf.New("P", "mm", "A4", "")
pdf.SetFontLoader(fontLoader{})

pdf.AddFont("RobotoCondensed", "", "RobotoCondensed-Regular.json")
pdf.AddFont("RobotoCondensed", "B", "RobotoCondensed-Bold.json")

```