### PR TITLE
Allow the tests to work on Windows

### DIFF
--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -109,6 +109,7 @@ func exampleFilename(baseStr string) string {
 
 func summary(err error, fileStr string) {
 	if err == nil {
+		fileStr = filepath.ToSlash(fileStr)
 		fmt.Printf("Successfully generated %s\n", fileStr)
 	} else {
 		fmt.Println(err)


### PR DESCRIPTION
The tests currently don't pass on Windows because of a silly little thing:

```
--- FAIL: ExampleFpdf_MoveTo (0.00s)
got:
Successfully generated pdf\Fpdf_MoveTo_path.pdf
want:
Successfully generated pdf/Fpdf_MoveTo_path.pdf
```

etc for all the tests. This tiny change allows the tests to pass.