### PR TITLE
Contribution packages specific interfaces.

### DIFF
--- a/contrib/httpimg/httpimg.go
+++ b/contrib/httpimg/httpimg.go
@@ -1,14 +1,25 @@
 package httpimg
 
 import (
-	"github.com/jung-kurt/gofpdf"
+	"io"
 	"net/http"
+
+	"github.com/jung-kurt/gofpdf"
 )
+
+// httpimgPdf is a partial interface that only implements the functions we need
+// from the PDF generator to put the HTTP images on the PDF.
+type httpimgPdf interface {
+	GetImageInfo(imageStr string) *gofpdf.ImageInfoType
+	ImageTypeFromMime(mimeStr string) string
+	RegisterImageReader(imgName, tp string, r io.Reader) *gofpdf.ImageInfoType
+	SetError(err error)
+}
 
 // Register registers a HTTP image. Downloading the image from the provided URL
 // and adding it to the PDF but not adding it to the page. Use Image() with the
 // same URL to add the image to the page.
-func Register(f *gofpdf.Fpdf, urlStr, tp string) (info *gofpdf.ImageInfoType) {
+func Register(f httpimgPdf, urlStr, tp string) (info *gofpdf.ImageInfoType) {
 	info = f.GetImageInfo(urlStr)
 
 	if info != nil {


### PR DESCRIPTION
Instead of forcing the type to be of gofpdf.Fpdf, we now use an
interface which could be whatever structure we want. This is useful for
third party libraries where they can define their own interface for the
PDF generator but still use these contribution packages.

Now external packages can implement their own PDF interface which
implements these methods and pass that along. Earlier, they would get
a type error.