### PR TITLE
Fpdf: add WriteAligned.

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2160,6 +2160,47 @@ func (f *Fpdf) WriteLinkID(h float64, displayStr string, linkID int) {
 	f.write(h, displayStr, linkID, "")
 }
 
+// WriteAligned is an implementation of Write that makes it possible to align
+// text.
+//
+// width indicates the width of the box the text will be drawn in. This is in
+// the unit of measure specified in New(). If it is set to 0, the bounding box
+//of the page will be taken (pageWidth - leftMargin - rightMargin).
+//
+// lineHeight indicates the line height in the unit of measure specified in
+// New().
+//
+// alignStr sees to horizontal alignment of the given textStr. The options are
+// "L", "C" and "R" (Left, Center, Right). The default is "L".
+func (f *Fpdf) WriteAligned(width, lineHeight float64, textStr, alignStr string) {
+	lMargin, _, rMargin, _ := f.GetMargins()
+
+	if width == 0 {
+		pageWidth, _ := f.GetPageSize()
+		width = pageWidth - (lMargin + rMargin)
+	}
+
+	lines := f.SplitLines([]byte(textStr), width)
+
+	for _, lineBt := range lines {
+		lineStr := string(lineBt[:])
+		lineWidth := f.GetStringWidth(lineStr)
+
+		switch alignStr {
+		case "C":
+			f.SetLeftMargin(lMargin + ((width - lineWidth) / 2))
+			f.Write(lineHeight, lineStr)
+			f.SetLeftMargin(lMargin)
+		case "R":
+			f.SetLeftMargin(lMargin + (width - lineWidth) - rMargin)
+			f.Write(lineHeight, lineStr)
+			f.SetLeftMargin(lMargin)
+		default:
+			f.Write(lineHeight, lineStr)
+		}
+	}
+}
+
 // Ln performs a line break. The current abscissa goes back to the left margin
 // and the ordinate increases by the amount passed in parameter. A negative
 // value of h indicates the height of the last printed cell.

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -463,6 +463,7 @@ func ExampleFpdf_HTMLBasicNew() {
 	_, lineHt = pdf.GetFontSize()
 	htmlStr := `You can now easily print text mixing different styles: <b>bold</b>, ` +
 		`<i>italic</i>, <u>underlined</u>, or <b><i><u>all at once</u></i></b>!<br><br>` +
+		`<center>You can also center text.</center>` +
 		`You can also insert links on text, such as ` +
 		`<a href="http://www.fpdf.org">www.fpdf.org</a>, or on an image: click on the logo.`
 	html := pdf.HTMLBasicNew()
@@ -486,6 +487,25 @@ func ExampleFpdf_AddFont() {
 	example.Summary(err, fileStr)
 	// Output:
 	// Successfully generated pdf/Fpdf_AddFont.pdf
+}
+
+// This example demonstrates how to align text with the Write function.
+func ExampleFpdf_WriteAligned() {
+	pdf := gofpdf.New("P", "mm", "A4", example.FontDir())
+	pdf.AddPage()
+	pdf.SetFont("Helvetica", "", 12)
+	pdf.WriteAligned(0, 35, "This text is the default alignment, Left", "")
+	pdf.Ln(35)
+	pdf.WriteAligned(0, 35, "This text is aligned Left", "L")
+	pdf.Ln(35)
+	pdf.WriteAligned(0, 35, "This text is aligned Center", "C")
+	pdf.Ln(35)
+	pdf.WriteAligned(0, 35, "This text is aligned Right", "R")
+	fileStr := example.Filename("Fpdf_WriteAligned")
+	err := pdf.OutputFileAndClose(fileStr)
+	example.Summary(err, fileStr)
+	// Output:
+	// Successfully generated pdf/Fpdf_WriteAligned.pdf
 }
 
 // This example demonstrates how images are included in documents.

--- a/htmlbasic.go
+++ b/htmlbasic.go
@@ -116,10 +116,10 @@ func (f *Fpdf) HTMLBasicNew() (html HTMLBasicType) {
 // Write prints text from the current position using the currently selected
 // font. See HTMLBasicNew() to create a receiver that is associated with the
 // PDF document instance. The text can be encoded with a basic subset of HTML
-// that includes hyperlinks and tags for italic (I), bold (B) and underscore
-// (U) attributes. When the right margin is reached a line break occurs and
-// text continues from the left margin. Upon method exit, the current position
-// is left at the end of the text.
+// that includes hyperlinks and tags for italic (I), bold (B), underscore
+// (U) and center (CENTER) attributes. When the right margin is reached a line
+// break occurs and text continues from the left margin. Upon method exit, the
+// current position is left at the end of the text.
 //
 // lineHt indicates the line height in the unit of measure specified in New().
 func (html *HTMLBasicType) Write(lineHt float64, htmlStr string) {
@@ -161,6 +161,7 @@ func (html *HTMLBasicType) Write(lineHt float64, htmlStr string) {
 	}
 	list := HTMLBasicTokenize(htmlStr)
 	var ok bool
+	alignStr := "L"
 	for _, el := range list {
 		switch el.Cat {
 		case 'T':
@@ -168,7 +169,7 @@ func (html *HTMLBasicType) Write(lineHt float64, htmlStr string) {
 				putLink(hrefStr, el.Str)
 				hrefStr = ""
 			} else {
-				html.pdf.Write(lineHt, el.Str)
+				html.pdf.WriteAligned(0, lineHt, el.Str, alignStr)
 			}
 		case 'O':
 			switch el.Str {
@@ -180,6 +181,9 @@ func (html *HTMLBasicType) Write(lineHt float64, htmlStr string) {
 				setStyle(0, 0, 1)
 			case "br":
 				html.pdf.Ln(lineHt)
+			case "center":
+				html.pdf.Ln(lineHt)
+				alignStr = "C"
 			case "a":
 				hrefStr, ok = el.Attr["href"]
 				if !ok {
@@ -194,7 +198,9 @@ func (html *HTMLBasicType) Write(lineHt float64, htmlStr string) {
 				setStyle(0, -1, 0)
 			case "u":
 				setStyle(0, 0, -1)
-
+			case "center":
+				html.pdf.Ln(lineHt)
+				alignStr = "L"
 			}
 		}
 	}


### PR DESCRIPTION
WriteAligned allows a user to write a single string and align it.
Previously, Write() would only write with Left alignment. Sometimes, you
want to align a specific text string to the center or the right.

HTMLBasic: add `<center>` tag.

This allows a user to center text within the HTML block. This way they
do not have to split up their input.

A new line will be created automatically before and after the centered
text.