### PR TITLE
Support reading and/or setting image dpi

### DIFF
--- a/def.go
+++ b/def.go
@@ -71,6 +71,7 @@ type ImageInfoType struct {
 	dp    string
 	trns  []int
 	scale float64 // document scaling factor
+	dpi   float64
 }
 
 // PointConvert returns the value of pt, expressed in points (1/72 inch), as a
@@ -97,17 +98,26 @@ func (f *Fpdf) UnitToPointConvert(u float64) (pt float64) {
 // Extent returns the width and height of the image in the units of the Fpdf
 // object.
 func (info *ImageInfoType) Extent() (wd, ht float64) {
-	return info.w / info.scale, info.h / info.scale
+	return info.Width(), info.Height()
 }
 
 // Width returns the width of the image in the units of the Fpdf object.
 func (info *ImageInfoType) Width() float64 {
-	return info.w / info.scale
+	return info.w / (info.scale * info.dpi / 72)
 }
 
 // Height returns the height of the image in the units of the Fpdf object.
 func (info *ImageInfoType) Height() float64 {
-	return info.h / info.scale
+	return info.h / (info.scale * info.dpi / 72)
+}
+
+// Dpi sets the dots per inch for an image
+// PNG images MAY have their dpi set automatically, if the image
+// specifies it. DPI information is not currently available
+// automatically for JPG and GIF images, so if it's important to
+// you, you can set it here. It defaults to 72 dpi.
+func (info *ImageInfoType) SetDpi(dpi float64) {
+	info.dpi = dpi
 }
 
 type fontFileType struct {


### PR DESCRIPTION
Addresses #66. Adds the ability to support reading dpi from PNG images, and setting
dpi on any image directly; this allows images to be displayed at the
designed size.

This PR provides backwards-compatible support for reading DPI from images that support it, and for setting DPI manually and then having it properly taken into account when calculating image size.

The changes could have been much simpler except for backwards compatibility. There were two major problems:

* The parameters for the Image call. The system uses 96 dpi if the w/h parameters to Image are 0,0, but the assumption in the calculation of `ImageInfoType.Width()`, etc is 72. The only way I've come up with to preserve both is to use w/h parameters of -1 to mean "use the dpi stored in the ImageInfoType". This kind of sucks but since a resolution of 1 pixel per inch is pretty unreasonable, it will be fine. (And frankly, if anyone needs that kind of resolution to print a billboard or something, w and h are both float64, so use -1.000001 or something and it'll be fine.)
* More troublesome was the code to automatically load the DPI information from a PNG file if it exists (it's an optional chunk in the PNG specification). However, this will break applications that were relying on the fact that it wasn't being used, which will basically be everyone who loads a PNG file without specifying DPI. 

What I did was create new functions: `ImageOptions`, `RegisterImageOptions` and `RegisterImageOptionsReader` where the tp parameter was replaced with an options parameter for additional options. It currently contains two fields -- `ImageType`, which replaces tp, and `ReadDpi`, which instructs the PNG reader to read the DPI chunk from the image file.

I have noted `Image`, `RegisterImage`, and `RegisterImageReader` as deprecated -- they just call the new functions now. 

One thing this doesn't currently have is the ability to read the DPI information from JPG files. This isn't possible with the default Go JPG library (or with the PNG library, but as fpdf was already reading raw PNG files it was easy to add it). I could write a utility function to do it if that seems desirable, but it seemed a bit beyond the scope of this PR. 

We could also go further and make the options object take additional parameters that would make the Image API a little cleaner. 