### PR TITLE
prevent panic when registering barcode fails

### DIFF
--- a/contrib/barcode/barcode.go
+++ b/contrib/barcode/barcode.go
@@ -20,6 +20,11 @@ package barcode
 import (
 	"bytes"
 	"errors"
+	"image/jpeg"
+	"io"
+	"strconv"
+	"sync"
+
 	"github.com/boombuler/barcode"
 	"github.com/boombuler/barcode/aztec"
 	"github.com/boombuler/barcode/codabar"
@@ -31,10 +36,6 @@ import (
 	"github.com/boombuler/barcode/twooffive"
 	"github.com/jung-kurt/gofpdf"
 	"github.com/ruudk/golang-pdf417"
-	"image/jpeg"
-	"io"
-	"strconv"
-	"sync"
 )
 
 // barcodes represents the barcodes that have been registered through this
@@ -197,6 +198,7 @@ func RegisterTwoOfFive(pdf barcodePdf, code string, interleaved bool) string {
 func registerBarcode(pdf barcodePdf, bcode barcode.Barcode, err error) string {
 	if err != nil {
 		pdf.SetError(err)
+		return ""
 	}
 
 	return Register(bcode)

--- a/contrib/barcode/barcode_test.go
+++ b/contrib/barcode/barcode_test.go
@@ -1,6 +1,8 @@
 package barcode_test
 
 import (
+	"testing"
+
 	"github.com/boombuler/barcode/code128"
 	"github.com/boombuler/barcode/qr"
 	"github.com/jung-kurt/gofpdf"
@@ -149,4 +151,10 @@ func ExampleRegisterPdf417() {
 	example.Summary(err, fileStr)
 	// Output:
 	// Successfully generated ../../pdf/contrib_barcode_RegisterPdf417.pdf
+}
+
+// This test ensures that no panic arises when an invalid barcode is registered.
+func TestRegisterCode128(t *testing.T) {
+	pdf := createPdf()
+	barcode.RegisterCode128(pdf, "Invalid character: é")
 }


### PR DESCRIPTION
I came across this bug when I tried to create a Code 128 barcode for non-ascii-128 string: The framework panics because the barcode it tries to register is `nil`.

I think this is a reasonable way of dealing with the bug, but @jelmersnoeck might know more, as it looks like he contributed to this file.