### PR TITLE
Ability to write XMP Metadata

### DIFF
--- a/def.go
+++ b/def.go
@@ -224,6 +224,7 @@ type Fpdf struct {
 	footerFncLpi     func(bool)                // function provided by app and called to write footer with last page flag
 	zoomMode         string                    // zoom display mode
 	layoutMode       string                    // layout display mode
+	xmp              []byte                    // XMP metadata
 	title            string                    // title
 	subject          string                    // subject
 	author           string                    // author

--- a/fpdf.go
+++ b/fpdf.go
@@ -3731,14 +3731,14 @@ func (f *Fpdf) enddoc() {
 	}
 	// Bookmarks
 	f.putbookmarks()
+	// Metadata
+	f.putxmp()
 	// 	Info
 	f.newobj()
 	f.out("<<")
 	f.putinfo()
 	f.out(">>")
 	f.out("endobj")
-	// Metadata
-	f.putxmp()
 	// 	Catalog
 	f.newobj()
 	f.out("<<")

--- a/fpdf.go
+++ b/fpdf.go
@@ -510,6 +510,11 @@ func (f *Fpdf) SetCreator(creatorStr string, isUTF8 bool) {
 	f.creator = creatorStr
 }
 
+// SetXmpMetadata defines XMP metadata that will be embedded with the document.
+func (f *Fpdf) SetXmpMetadata(xmpStream []byte) {
+	f.xmp = xmpStream
+}
+
 // AliasNbPages defines an alias for the total number of pages. It will be
 // substituted as the document is closed. An empty string is replaced with the
 // string "{nb}".
@@ -3650,6 +3655,16 @@ func (f *Fpdf) puttrailer() {
 	}
 }
 
+func (f *Fpdf) putxmp() {
+	if len(f.xmp) == 0 {
+		return
+	}
+	f.newobj()
+	f.outf("<< /Type /Metadata /Subtype /XML /Length %d >>", len(f.xmp))
+	f.putstream(f.xmp)
+	f.out("endobj")
+}
+
 func (f *Fpdf) putbookmarks() {
 	nb := len(f.outlines)
 	if nb > 0 {
@@ -3722,6 +3737,8 @@ func (f *Fpdf) enddoc() {
 	f.putinfo()
 	f.out(">>")
 	f.out("endobj")
+	// Metadata
+	f.putxmp()
 	// 	Catalog
 	f.newobj()
 	f.out("<<")


### PR DESCRIPTION
This PR adds a new function `SetXmpMetadata(xmpStream []byte)` to the API which allows the caller to insert a `/Type /Metadata /Subtype /XML` stream into the PDF file on output.

Then contents of the metadata stream must be a valid XMP metadata packet in XML format. It's up to the caller to generate such a packet, e.g. by using a library like http://github.com/echa/go-xmp. However, SetXmpMetadata does not perform any validity checks to keep the implementation lean.

I couldn't find a way to make this work with the existing API using the RawWrite* functions since they cannot be called during output (`Fpdf.enddoc()` writes PDF header, contents and trailer in one go).