### PR TITLE
Added flag to print PDF byte diffs

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -75,9 +75,9 @@ func writeBytes(leadStr string, startPos int, sl []byte) {
 	fmt.Printf("|\n")
 }
 
-func checkBytes(pos int, sl1, sl2 []byte) (eq bool) {
+func checkBytes(pos int, sl1, sl2 []byte, printDiff bool) (eq bool) {
 	eq = bytes.Equal(sl1, sl2)
-	if !eq {
+	if !eq && printDiff {
 		writeBytes("<", pos, sl1)
 		writeBytes(">", pos, sl2)
 	}
@@ -86,7 +86,7 @@ func checkBytes(pos int, sl1, sl2 []byte) (eq bool) {
 
 // CompareBytes compares the bytes referred to by sl1 with those referred to by
 // sl2. Nil is returned if the buffers are equal, otherwise an error.
-func CompareBytes(sl1, sl2 []byte) (err error) {
+func CompareBytes(sl1, sl2 []byte, printDiff bool) (err error) {
 	var posStart, posEnd, len1, len2, length int
 	var diffs bool
 
@@ -101,7 +101,7 @@ func CompareBytes(sl1, sl2 []byte) (err error) {
 		if posEnd > length {
 			posEnd = length
 		}
-		if !checkBytes(posStart, sl1[posStart:posEnd], sl2[posStart:posEnd]) {
+		if !checkBytes(posStart, sl1[posStart:posEnd], sl2[posStart:posEnd], printDiff) {
 			diffs = true
 		}
 		posStart = posEnd
@@ -115,13 +115,13 @@ func CompareBytes(sl1, sl2 []byte) (err error) {
 // ComparePDFs reads and compares the full contents of the two specified
 // readers byte-for-byte. Nil is returned if the buffers are equal, otherwise
 // an error.
-func ComparePDFs(rdr1, rdr2 io.Reader) (err error) {
+func ComparePDFs(rdr1, rdr2 io.Reader, printDiff bool) (err error) {
 	var b1, b2 *bytes.Buffer
 	_, err = b1.ReadFrom(rdr1)
 	if err == nil {
 		_, err = b2.ReadFrom(rdr2)
 		if err == nil {
-			err = CompareBytes(b1.Bytes(), b2.Bytes())
+			err = CompareBytes(b1.Bytes(), b2.Bytes(), printDiff)
 		}
 	}
 	return
@@ -130,13 +130,13 @@ func ComparePDFs(rdr1, rdr2 io.Reader) (err error) {
 // ComparePDFFiles reads and compares the full contents of the two specified
 // files byte-for-byte. Nil is returned if the file contents are equal, or if
 // the second file is missing, otherwise an error.
-func ComparePDFFiles(file1Str, file2Str string) (err error) {
+func ComparePDFFiles(file1Str, file2Str string, printDiff bool) (err error) {
 	var sl1, sl2 []byte
 	sl1, err = ioutil.ReadFile(file1Str)
 	if err == nil {
 		sl2, err = ioutil.ReadFile(file2Str)
 		if err == nil {
-			err = CompareBytes(sl1, sl2)
+			err = CompareBytes(sl1, sl2, printDiff)
 		} else {
 			// Second file is missing; treat this as success
 			err = nil

--- a/internal/example/example.go
+++ b/internal/example/example.go
@@ -104,7 +104,7 @@ func referenceCompare(fileStr string) (err error) {
 	err = os.MkdirAll(refDirStr, 0755)
 	if err == nil {
 		refFileStr = filepath.Join(refDirStr, baseFileStr)
-		err = gofpdf.ComparePDFFiles(fileStr, refFileStr)
+		err = gofpdf.ComparePDFFiles(fileStr, refFileStr, true)
 	}
 	return
 }

--- a/internal/example/example.go
+++ b/internal/example/example.go
@@ -104,7 +104,7 @@ func referenceCompare(fileStr string) (err error) {
 	err = os.MkdirAll(refDirStr, 0755)
 	if err == nil {
 		refFileStr = filepath.Join(refDirStr, baseFileStr)
-		err = gofpdf.ComparePDFFiles(fileStr, refFileStr, true)
+		err = gofpdf.ComparePDFFiles(fileStr, refFileStr, false)
 	}
 	return
 }


### PR DESCRIPTION
Currently diffs between different PDFs are printed to stdout. This is annoying, especially if the PDFs are quite large. The output is kind of useless anyway. Added a flag to enable/disable this behavior. 