### PR TITLE
Add consts for page orientations

### DIFF
--- a/def.go
+++ b/def.go
@@ -39,6 +39,11 @@ type gradientType struct {
 	objNum            int
 }
 
+const (
+	OrientationPortrait  = "portrait"
+	OrientationLandscape = "landscape"
+)
+
 type colorMode int
 
 const (

--- a/fpdf.go
+++ b/fpdf.go
@@ -59,7 +59,9 @@ func (b *fmtBuffer) printf(fmtStr string, args ...interface{}) {
 func fpdfNew(orientationStr, unitStr, sizeStr, fontDirStr string, size SizeType) (f *Fpdf) {
 	f = new(Fpdf)
 	if orientationStr == "" {
-		orientationStr = "P"
+		orientationStr = "p"
+	} else {
+		orientationStr = strings.ToLower(orientationStr)
 	}
 	if unitStr == "" {
 		unitStr = "mm"
@@ -143,7 +145,6 @@ func fpdfNew(orientationStr, unitStr, sizeStr, fontDirStr string, size SizeType)
 	}
 	f.curPageSize = f.defPageSize
 	// Page orientation
-	orientationStr = strings.ToLower(orientationStr)
 	switch orientationStr {
 	case "p", "portrait":
 		f.defOrientation = "P"

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -191,7 +191,7 @@ func lorem() string {
 // finally retrieved with the output call where it can be handled by the
 // application.
 func Example() {
-	pdf := gofpdf.New("P", "mm", "A4", "")
+	pdf := gofpdf.New(gofpdf.OrientationPortrait, "mm", "A4", "")
 	pdf.AddPage()
 	pdf.SetFont("Arial", "B", 16)
 	pdf.Cell(40, 10, "Hello World!")


### PR DESCRIPTION
As a new user I'd prefer to have page orientations available as consts, so that it's easier for me to get started. Also, I moved `strings.ToLower(..)` call on `orientationStr` to the top of the function so that you don't _lowerize_ a default value, and the sanitization in a single place.