### PR TITLE
EOF error when using reader

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2990,7 +2990,7 @@ func (f *Fpdf) parsepng(r io.Reader, readdpi bool) (info *ImageInfoType) {
 
 func (f *Fpdf) readBeInt32(r io.Reader) (val int32) {
 	err := binary.Read(r, binary.BigEndian, &val)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		f.err = err
 	}
 	return


### PR DESCRIPTION
While you're using a reader for i.e. an image you'll receive an EOF from go's io package which leads to pdf creation error