### PR TITLE
Handle URL's for images if URL is given instead of a local fs path.

### DIFF
--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -719,7 +719,7 @@ func ExampleFpdf_Image() {
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	pdf.AddPage()
 	pdf.SetFont("Arial", "", 11)
-	pdf.Image(example.ImageFile("logo.png"), 10, 10, 30, 0, false, "", 0, "")
+	pdf.Image("https://raw.githubusercontent.com/jung-kurt/gofpdf/master/image/logo.png", 10, 10, 30, 0, false, "", 0, "")
 	pdf.Text(50, 20, "logo.png")
 	pdf.Image(example.ImageFile("logo.gif"), 10, 40, 30, 0, false, "", 0, "")
 	pdf.Text(50, 50, "logo.gif")


### PR DESCRIPTION
## Context:
In php's version of fpdf, we are able to use a http URL as argument to `fpdf.Image()` like
```php
// Insert a dynamic image from a URL
$pdf->Image('http://chart.googleapis.com/chart?cht=p3&chd=t:60,40&chs=250x100&chl=Hello|World',60,30,90,0,'PNG');
```
Currently, we only can read from the local filesystem using `os.Open`.

## Summary
This commit checks if the path `fileStr` passed to `RegisterImageOptions` is a http URL, and if so, attempts to fetch the image. It otherwise defaults to the usual behaviour of reading via `os.Open`.
