### PR TITLE
Added Ability to turn template into a byte string

### DIFF
--- a/def.go
+++ b/def.go
@@ -18,6 +18,7 @@ package gofpdf
 
 import (
 	"bytes"
+	"encoding/gob"
 	"io"
 	"time"
 )
@@ -173,6 +174,101 @@ type ImageInfoType struct {
 	trns  []int
 	scale float64 // document scaling factor
 	dpi   float64
+}
+
+func (info *ImageInfoType) GobEncode() ([]byte, error) {
+	w := new(bytes.Buffer)
+	encoder := gob.NewEncoder(w)
+
+	err := encoder.Encode(info.data)
+	if err == nil {
+		err = encoder.Encode(info.smask)
+	}
+	if err == nil {
+		err = encoder.Encode(info.i)
+	}
+	if err == nil {
+		err = encoder.Encode(info.n)
+	}
+	if err == nil {
+		err = encoder.Encode(info.w)
+	}
+	if err == nil {
+		err = encoder.Encode(info.h)
+	}
+	if err == nil {
+		err = encoder.Encode(info.cs)
+	}
+	if err == nil {
+		err = encoder.Encode(info.pal)
+	}
+	if err == nil {
+		err = encoder.Encode(info.bpc)
+	}
+	if err == nil {
+		err = encoder.Encode(info.f)
+	}
+	if err == nil {
+		err = encoder.Encode(info.dp)
+	}
+	if err == nil {
+		err = encoder.Encode(info.trns)
+	}
+	if err == nil {
+		err = encoder.Encode(info.scale)
+	}
+	if err == nil {
+		err = encoder.Encode(info.dpi)
+	}
+
+	return w.Bytes(), err
+}
+
+func (info *ImageInfoType) GobDecode(buf []byte) error {
+	r := bytes.NewBuffer(buf)
+	decoder := gob.NewDecoder(r)
+
+	err := decoder.Decode(&info.data)
+	if err == nil {
+		err = decoder.Decode(&info.smask)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.i)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.n)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.w)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.h)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.cs)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.pal)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.bpc)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.f)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.dp)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.trns)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.scale)
+	}
+	if err == nil {
+		err = decoder.Decode(&info.dpi)
+	}
+	return err
 }
 
 // PointConvert returns the value of pt, expressed in points (1/72 inch), as a

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -19,6 +19,7 @@ package gofpdf_test
 import (
 	"bufio"
 	"bytes"
+	"encoding/gob"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1950,10 +1951,23 @@ func ExampleFpdf_CreateTemplate() {
 	pdf.SetLineWidth(2.5)
 	pdf.SetFont("Arial", "B", 16)
 
+	template3 := new(gofpdf.FpdfTpl)
+	b := new(bytes.Buffer)
+	enc := gob.NewEncoder(b)
+
+	if err := enc.Encode(template); err != nil {
+		pdf.SetError(err)
+	}
+
+	dec := gob.NewDecoder(b)
+	if err := dec.Decode(template3); err != nil {
+		pdf.SetError(err)
+	}
+
 	pdf.AddPage()
-	pdf.UseTemplate(template)
-	pdf.UseTemplateScaled(template, gofpdf.PointType{X: 0, Y: 30}, tplSize)
-	pdf.UseTemplateScaled(template, gofpdf.PointType{X: 0, Y: 60}, tplSize.ScaleBy(1.4))
+	pdf.UseTemplate(template3)
+	pdf.UseTemplateScaled(template3, gofpdf.PointType{X: 0, Y: 30}, tplSize)
+	pdf.UseTemplateScaled(template3, gofpdf.PointType{X: 0, Y: 60}, tplSize.ScaleBy(1.4))
 	pdf.Line(40, 210, 60, 210)
 	pdf.Text(40, 200, "Template example page 1")
 

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -19,7 +19,6 @@ package gofpdf_test
 import (
 	"bufio"
 	"bytes"
-	"encoding/gob"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1951,18 +1950,9 @@ func ExampleFpdf_CreateTemplate() {
 	pdf.SetLineWidth(2.5)
 	pdf.SetFont("Arial", "B", 16)
 
-	template3 := new(gofpdf.FpdfTpl)
-	b := new(bytes.Buffer)
-	enc := gob.NewEncoder(b)
-
-	if err := enc.Encode(template); err != nil {
-		pdf.SetError(err)
-	}
-
-	dec := gob.NewDecoder(b)
-	if err := dec.Decode(template3); err != nil {
-		pdf.SetError(err)
-	}
+	// serialize and deserialize template
+	b, _ := template2.Serialize()
+	template3, _ := gofpdf.DeserializeTemplate(b)
 
 	pdf.AddPage()
 	pdf.UseTemplate(template3)

--- a/template.go
+++ b/template.go
@@ -108,6 +108,7 @@ type Template interface {
 	Bytes() []byte
 	Images() map[string]*ImageInfoType
 	Templates() []Template
+	Serialize() ([]byte, error)
 	gob.GobDecoder
 	gob.GobEncoder
 }

--- a/template.go
+++ b/template.go
@@ -18,6 +18,7 @@ package gofpdf
  */
 
 import (
+	"encoding/gob"
 	"sort"
 )
 
@@ -107,6 +108,8 @@ type Template interface {
 	Bytes() []byte
 	Images() map[string]*ImageInfoType
 	Templates() []Template
+	gob.GobDecoder
+	gob.GobEncoder
 }
 
 func (f *Fpdf) templateFontCatalog() {

--- a/template_impl.go
+++ b/template_impl.go
@@ -3,6 +3,7 @@ package gofpdf
 import (
 	"bytes"
 	"encoding/gob"
+	"reflect"
 )
 
 /*
@@ -136,7 +137,24 @@ func (t *FpdfTpl) GobDecode(buf []byte) error {
 		}
 	}
 
+	t.relinkPointers(t.images)
+
 	return err
+}
+
+func (t *FpdfTpl) relinkPointers(images map[string]*ImageInfoType) {
+	for gKey, _ := range images {
+		for key, _ := range t.images {
+			if reflect.DeepEqual(t.images[key], images[gKey]) {
+				t.images[key] = images[gKey]
+			}
+		}
+	}
+
+	for x := 0; x < len(t.templates); x++ {
+		innerT := t.templates[x].(*FpdfTpl)
+		innerT.relinkPointers(t.images)
+	}
 }
 
 // Tpl is an Fpdf used for writing a template. It has most of the facilities of

--- a/template_impl.go
+++ b/template_impl.go
@@ -1,5 +1,10 @@
 package gofpdf
 
+import (
+	"bytes"
+	"encoding/gob"
+)
+
 /*
  * Copyright (c) 2015 Kurt Jung (Gmail: kurt.w.jung),
  *   Marcus Downing, Jan Slabon (Setasign)
@@ -78,6 +83,60 @@ func (t *FpdfTpl) Images() map[string]*ImageInfoType {
 // Templates returns a list of templates used in this template
 func (t *FpdfTpl) Templates() []Template {
 	return t.templates
+}
+
+func (t *FpdfTpl) GobEncode() ([]byte, error) {
+	w := new(bytes.Buffer)
+	encoder := gob.NewEncoder(w)
+
+	err := encoder.Encode(t.id)
+	if err == nil {
+		err = encoder.Encode(t.corner)
+	}
+	if err == nil {
+		err = encoder.Encode(t.size)
+	}
+	if err == nil {
+		err = encoder.Encode(t.bytes)
+	}
+	if err == nil {
+		err = encoder.Encode(t.images)
+	}
+	if err == nil {
+		err = encoder.Encode(t.templates)
+	}
+
+	return w.Bytes(), err
+}
+
+func (t *FpdfTpl) GobDecode(buf []byte) error {
+	r := bytes.NewBuffer(buf)
+	decoder := gob.NewDecoder(r)
+
+	err := decoder.Decode(&t.id)
+	if err == nil {
+		err = decoder.Decode(&t.corner)
+	}
+	if err == nil {
+		err = decoder.Decode(&t.size)
+	}
+	if err == nil {
+		err = decoder.Decode(&t.bytes)
+	}
+	if err == nil {
+		err = decoder.Decode(&t.images)
+	}
+	if err == nil {
+		templates := make([]*FpdfTpl, 0)
+		err = decoder.Decode(&templates)
+		t.templates = make([]Template, len(templates))
+
+		for x := 0; x < len(templates); x++ {
+			t.templates[x] = templates[x]
+		}
+	}
+
+	return err
 }
 
 // Tpl is an Fpdf used for writing a template. It has most of the facilities of

--- a/template_impl.go
+++ b/template_impl.go
@@ -86,6 +86,23 @@ func (t *FpdfTpl) Templates() []Template {
 	return t.templates
 }
 
+// Turn a template into a byte string for later deserialization
+func (t *FpdfTpl) Serialize() ([]byte, error) {
+	b := new(bytes.Buffer)
+	enc := gob.NewEncoder(b)
+	err := enc.Encode(t)
+
+	return b.Bytes(), err
+}
+
+// Create a template from a previously serialized template
+func DeserializeTemplate(b []byte) (Template, error) {
+	tpl := new(FpdfTpl)
+	dec := gob.NewDecoder(bytes.NewBuffer(b))
+	err := dec.Decode(tpl)
+	return tpl, err
+}
+
 // returns the next layer of children images, it doesn't dig into
 // children of children. Applies template namespace to keys to ensure
 // no collisions. See UseTemplateScaled


### PR DESCRIPTION
Not sure if you want to pull this in, but it makes the default FpdfTpl serialize-able using gob. This allows an external package to save a template to memory or a file and turn it back into a template.

The one issue is all templates within a template are assumed to also be FpdfTpl objects. Considering the interface Tpl is public it would allow a user to create an external struct that implements Tpl that could not be a child of a FpdfTpl object.

Also there may be a better way to do this using reflection that wouldn't need to be updated in the event more properties are added to the FpdfTpl and ImageInfoType structs. Although I'm not sure that is possible considering they are non exported fields.

Anyway, figured I would send this your way too.