### PR TITLE
Added page boxes

### DIFF
--- a/def.go
+++ b/def.go
@@ -399,6 +399,7 @@ type Pdf interface {
 	SetLineWidth(width float64)
 	SetLink(link int, y float64, page int)
 	SetMargins(left, top, right float64)
+	SetPageBox(t string, pb PageBox)
 	SetProtection(actionFlag byte, userPassStr, ownerPassStr string)
 	SetRightMargin(margin float64)
 	SetSubject(subjectStr string, isUTF8 bool)
@@ -442,93 +443,100 @@ type Pdf interface {
 	Writef(h float64, fmtStr string, args ...interface{})
 }
 
+type PageBox struct {
+	SizeType
+	PointType
+}
+
 // Fpdf is the principal structure for creating a single PDF document
 type Fpdf struct {
-	page             int                       // current page number
-	n                int                       // current object number
-	offsets          []int                     // array of object offsets
-	templates        map[int64]Template        // templates used in this document
-	templateObjects  map[int64]int             // template object IDs within this document
-	buffer           fmtBuffer                 // buffer holding in-memory PDF
-	pages            []*bytes.Buffer           // slice[page] of page content; 1-based
-	state            int                       // current document state
-	compress         bool                      // compression flag
-	k                float64                   // scale factor (number of points in user unit)
-	defOrientation   string                    // default orientation
-	curOrientation   string                    // current orientation
-	stdPageSizes     map[string]SizeType       // standard page sizes
-	defPageSize      SizeType                  // default page size
-	curPageSize      SizeType                  // current page size
-	pageSizes        map[int]SizeType          // used for pages with non default sizes or orientations
-	unitStr          string                    // unit of measure for all rendered objects except fonts
-	wPt, hPt         float64                   // dimensions of current page in points
-	w, h             float64                   // dimensions of current page in user unit
-	lMargin          float64                   // left margin
-	tMargin          float64                   // top margin
-	rMargin          float64                   // right margin
-	bMargin          float64                   // page break margin
-	cMargin          float64                   // cell margin
-	x, y             float64                   // current position in user unit
-	lasth            float64                   // height of last printed cell
-	lineWidth        float64                   // line width in user unit
-	fontpath         string                    // path containing fonts
-	fontLoader       FontLoader                // used to load font files from arbitrary locations
-	coreFonts        map[string]bool           // array of core font names
-	fonts            map[string]fontDefType    // array of used fonts
-	fontFiles        map[string]fontFileType   // array of font files
-	diffs            []string                  // array of encoding differences
-	fontFamily       string                    // current font family
-	fontStyle        string                    // current font style
-	underline        bool                      // underlining flag
-	currentFont      fontDefType               // current font info
-	fontSizePt       float64                   // current font size in points
-	fontSize         float64                   // current font size in user unit
-	ws               float64                   // word spacing
-	images           map[string]*ImageInfoType // array of used images
-	aliasMap         map[string]string         // map of alias->replacement
-	pageLinks        [][]linkType              // pageLinks[page][link], both 1-based
-	links            []intLinkType             // array of internal links
-	outlines         []outlineType             // array of outlines
-	outlineRoot      int                       // root of outlines
-	autoPageBreak    bool                      // automatic page breaking
-	acceptPageBreak  func() bool               // returns true to accept page break
-	pageBreakTrigger float64                   // threshold used to trigger page breaks
-	inHeader         bool                      // flag set when processing header
-	headerFnc        func()                    // function provided by app and called to write header
-	headerHomeMode   bool                      // set position to home after headerFnc is called
-	inFooter         bool                      // flag set when processing footer
-	footerFnc        func()                    // function provided by app and called to write footer
-	footerFncLpi     func(bool)                // function provided by app and called to write footer with last page flag
-	zoomMode         string                    // zoom display mode
-	layoutMode       string                    // layout display mode
-	xmp              []byte                    // XMP metadata
-	title            string                    // title
-	subject          string                    // subject
-	author           string                    // author
-	keywords         string                    // keywords
-	creator          string                    // creator
-	creationDate     time.Time                 // override for dcoument CreationDate value
-	aliasNbPagesStr  string                    // alias for total number of pages
-	pdfVersion       string                    // PDF version number
-	fontDirStr       string                    // location of font definition files
-	capStyle         int                       // line cap style: butt 0, round 1, square 2
-	joinStyle        int                       // line segment join style: miter 0, round 1, bevel 2
-	dashArray        []float64                 // dash array
-	dashPhase        float64                   // dash phase
-	blendList        []blendModeType           // slice[idx] of alpha transparency modes, 1-based
-	blendMap         map[string]int            // map into blendList
-	blendMode        string                    // current blend mode
-	alpha            float64                   // current transpacency
-	gradientList     []gradientType            // slice[idx] of gradient records
-	clipNest         int                       // Number of active clipping contexts
-	transformNest    int                       // Number of active transformation contexts
-	err              error                     // Set if error occurs during life cycle of instance
-	protect          protectType               // document protection structure
-	layer            layerRecType              // manages optional layers in document
-	catalogSort      bool                      // sort resource catalogs in document
-	nJs              int                       // JavaScript object number
-	javascript       *string                   // JavaScript code to include in the PDF
-	colorFlag        bool                      // indicates whether fill and text colors are different
+	page             int                        // current page number
+	n                int                        // current object number
+	offsets          []int                      // array of object offsets
+	templates        map[int64]Template         // templates used in this document
+	templateObjects  map[int64]int              // template object IDs within this document
+	buffer           fmtBuffer                  // buffer holding in-memory PDF
+	pages            []*bytes.Buffer            // slice[page] of page content; 1-based
+	state            int                        // current document state
+	compress         bool                       // compression flag
+	k                float64                    // scale factor (number of points in user unit)
+	defOrientation   string                     // default orientation
+	curOrientation   string                     // current orientation
+	stdPageSizes     map[string]SizeType        // standard page sizes
+	defPageSize      SizeType                   // default page size
+	defPageBoxes     map[string]PageBox         // default page size
+	curPageSize      SizeType                   // current page size
+	pageSizes        map[int]SizeType           // used for pages with non default sizes or orientations
+	pageBoxes        map[int]map[string]PageBox // used to define the crop, trim, bleed and art boxes
+	unitStr          string                     // unit of measure for all rendered objects except fonts
+	wPt, hPt         float64                    // dimensions of current page in points
+	w, h             float64                    // dimensions of current page in user unit
+	lMargin          float64                    // left margin
+	tMargin          float64                    // top margin
+	rMargin          float64                    // right margin
+	bMargin          float64                    // page break margin
+	cMargin          float64                    // cell margin
+	x, y             float64                    // current position in user unit
+	lasth            float64                    // height of last printed cell
+	lineWidth        float64                    // line width in user unit
+	fontpath         string                     // path containing fonts
+	fontLoader       FontLoader                 // used to load font files from arbitrary locations
+	coreFonts        map[string]bool            // array of core font names
+	fonts            map[string]fontDefType     // array of used fonts
+	fontFiles        map[string]fontFileType    // array of font files
+	diffs            []string                   // array of encoding differences
+	fontFamily       string                     // current font family
+	fontStyle        string                     // current font style
+	underline        bool                       // underlining flag
+	currentFont      fontDefType                // current font info
+	fontSizePt       float64                    // current font size in points
+	fontSize         float64                    // current font size in user unit
+	ws               float64                    // word spacing
+	images           map[string]*ImageInfoType  // array of used images
+	aliasMap         map[string]string          // map of alias->replacement
+	pageLinks        [][]linkType               // pageLinks[page][link], both 1-based
+	links            []intLinkType              // array of internal links
+	outlines         []outlineType              // array of outlines
+	outlineRoot      int                        // root of outlines
+	autoPageBreak    bool                       // automatic page breaking
+	acceptPageBreak  func() bool                // returns true to accept page break
+	pageBreakTrigger float64                    // threshold used to trigger page breaks
+	inHeader         bool                       // flag set when processing header
+	headerFnc        func()                     // function provided by app and called to write header
+	headerHomeMode   bool                       // set position to home after headerFnc is called
+	inFooter         bool                       // flag set when processing footer
+	footerFnc        func()                     // function provided by app and called to write footer
+	footerFncLpi     func(bool)                 // function provided by app and called to write footer with last page flag
+	zoomMode         string                     // zoom display mode
+	layoutMode       string                     // layout display mode
+	xmp              []byte                     // XMP metadata
+	title            string                     // title
+	subject          string                     // subject
+	author           string                     // author
+	keywords         string                     // keywords
+	creator          string                     // creator
+	creationDate     time.Time                  // override for dcoument CreationDate value
+	aliasNbPagesStr  string                     // alias for total number of pages
+	pdfVersion       string                     // PDF version number
+	fontDirStr       string                     // location of font definition files
+	capStyle         int                        // line cap style: butt 0, round 1, square 2
+	joinStyle        int                        // line segment join style: miter 0, round 1, bevel 2
+	dashArray        []float64                  // dash array
+	dashPhase        float64                    // dash phase
+	blendList        []blendModeType            // slice[idx] of alpha transparency modes, 1-based
+	blendMap         map[string]int             // map into blendList
+	blendMode        string                     // current blend mode
+	alpha            float64                    // current transpacency
+	gradientList     []gradientType             // slice[idx] of gradient records
+	clipNest         int                        // Number of active clipping contexts
+	transformNest    int                        // Number of active transformation contexts
+	err              error                      // Set if error occurs during life cycle of instance
+	protect          protectType                // document protection structure
+	layer            layerRecType               // manages optional layers in document
+	catalogSort      bool                       // sort resource catalogs in document
+	nJs              int                        // JavaScript object number
+	javascript       *string                    // JavaScript code to include in the PDF
+	colorFlag        bool                       // indicates whether fill and text colors are different
 	color            struct {
 		// Composite values of colors
 		draw, fill, text colorType

--- a/fpdf.go
+++ b/fpdf.go
@@ -359,7 +359,7 @@ func (f *Fpdf) SetPageBox(t string, pb PageBox) {
 	case "artbox":
 		t = "ArtBox"
 	default:
-		f.err = fmt.Sprintf("%s is not a valid page box type")
+		f.err = fmt.Errorf("%s is not a valid page box type", t)
 		return
 	}
 

--- a/fpdf.go
+++ b/fpdf.go
@@ -358,6 +358,9 @@ func (f *Fpdf) SetPageBox(t string, pb PageBox) {
 		fallthrough
 	case "artbox":
 		t = "ArtBox"
+	default:
+		f.err = fmt.Sprintf("%s is not a valid page box type")
+		return
 	}
 
 	pb.X = pb.X * f.k


### PR DESCRIPTION
Added a new method `SetPageBox(t string, pb PageBox)` which allows you to add an art, crop, bleed and trim box to the document. The method applies the box type to the current page as well as the default. When a new page is added, all the default boxes are applied to the page. I considered adding pageboxes as a parameter when creating a new Fpdf object, but figured it would be better not to break the api.

A PageBox struct is just a PointType and a SizeType combined.