### PR TITLE
Added the ability to have multiple pages in a template

### DIFF
--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -64,7 +64,7 @@ func TestFpdfImplementPdf(t *testing.T) {
 	var _ gofpdf.Pdf = (*gofpdf.Tpl)(nil)
 }
 
-// Testcase to ensure new paged templates work
+// TestPagedTemplate ensures new paged templates work
 func TestPagedTemplate(t *testing.T) {
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	tpl := pdf.CreateTemplate(func(t *gofpdf.Tpl) {

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -64,6 +64,42 @@ func TestFpdfImplementPdf(t *testing.T) {
 	var _ gofpdf.Pdf = (*gofpdf.Tpl)(nil)
 }
 
+// Testcase to ensure new paged templates work
+func TestPagedTemplate(t *testing.T) {
+	pdf := gofpdf.New("P", "mm", "A4", "")
+	tpl := pdf.CreateTemplate(func(t *gofpdf.Tpl) {
+		// this will be the second page, as a page is already
+		// created by default
+		t.AddPage()
+		t.AddPage()
+		t.AddPage()
+	})
+
+	if tpl.NumPages() != 4 {
+		t.Fatalf("The template does not have the correct number of pages %d", tpl.NumPages())
+	}
+
+	tplPages := tpl.FromPages()
+	for x := 0; x < len(tplPages); x++ {
+		pdf.AddPage()
+		pdf.UseTemplate(tplPages[x])
+	}
+
+	// get the last template
+	tpl2, err := tpl.FromPage(tpl.NumPages())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// the objects should be the exact same, as the
+	// template will represent the last page by default
+	// therefore no new id should be set, and the object
+	// should be the same object
+	if fmt.Sprintf("%p", tpl2) != fmt.Sprintf("%p", tpl) {
+		t.Fatal("Template no longer respecting initial template object")
+	}
+}
+
 // TestIssue0116 addresses issue 116 in which library silently fails after
 // calling CellFormat when no font has been set.
 func TestIssue0116(t *testing.T) {

--- a/template.go
+++ b/template.go
@@ -124,6 +124,9 @@ type Template interface {
 	Bytes() []byte
 	Images() map[string]*ImageInfoType
 	Templates() []Template
+	NumPages() int
+	FromPage(int) (Template, error)
+	FromPages() []Template
 	Serialize() ([]byte, error)
 	gob.GobDecoder
 	gob.GobEncoder


### PR DESCRIPTION
Templates are now aware of the number of pages they have. The main additions are the FromPage and FromPages methods which allow you to extract a Template from a template if you pass in the page number. It follows the same page mechanism as FPDF where pages start in the index 1.

Needs tests.