### PR TITLE
Refactored Encode and Decode functions, Fixed Template ID Conflicts

### DIFF
--- a/def.go
+++ b/def.go
@@ -486,8 +486,8 @@ type Fpdf struct {
 	page             int                        // current page number
 	n                int                        // current object number
 	offsets          []int                      // array of object offsets
-	templates        map[int64]Template         // templates used in this document
-	templateObjects  map[int64]int              // template object IDs within this document
+	templates        map[string]Template        // templates used in this document
+	templateObjects  map[string]int             // template object IDs within this document
 	buffer           fmtBuffer                  // buffer holding in-memory PDF
 	pages            []*bytes.Buffer            // slice[page] of page content; 1-based
 	state            int                        // current document state

--- a/fpdf.go
+++ b/fpdf.go
@@ -83,8 +83,8 @@ func fpdfNew(orientationStr, unitStr, sizeStr, fontDirStr string, size SizeType)
 	f.fonts = make(map[string]fontDefType)
 	f.fontFiles = make(map[string]fontFileType)
 	f.diffs = make([]string, 0, 8)
-	f.templates = make(map[int64]Template)
-	f.templateObjects = make(map[int64]int)
+	f.templates = make(map[string]Template)
+	f.templateObjects = make(map[string]int)
 	f.images = make(map[string]*ImageInfoType)
 	f.pageLinks = make([][]linkType, 0, 8)
 	f.pageLinks = append(f.pageLinks, make([]linkType, 0, 0)) // pageLinks[0] is unused (1-based)
@@ -3559,8 +3559,8 @@ func (f *Fpdf) putxobjectdict() {
 		}
 	}
 	{
-		var keyList []int64
-		var key int64
+		var keyList []string
+		var key string
 		var tpl Template
 		keyList = templateKeyList(f.templates, f.catalogSort)
 		for _, key = range keyList {
@@ -3568,7 +3568,7 @@ func (f *Fpdf) putxobjectdict() {
 			// for _, tpl := range f.templates {
 			id := tpl.ID()
 			if objID, ok := f.templateObjects[id]; ok {
-				f.outf("/TPL%d %d 0 R", id, objID)
+				f.outf("/TPL%s %d 0 R", id, objID)
 			}
 		}
 	}


### PR DESCRIPTION
- Updated Encode and Decode to ensure templates and images are pointers to the original objects
- Refactored so encoding no longer has to create p and o labels for images
- removed id from template and generate it using Bytes instead.