### PR TITLE
Fixed id collisions with fonts when encoding and decoding

### DIFF
--- a/def.go
+++ b/def.go
@@ -681,9 +681,9 @@ type fontDefType struct {
 	File         string       // "Redressed.z"
 	Size1, Size2 int          // Type1 values
 	OriginalSize int          // Size of uncompressed font file
-	I            int          // 1-based position in font list, set by font loader, not this program
 	N            int          // Set by font loader
 	DiffN        int          // Position of diff in app array, set by font loader
+	i            string       // 1-based position in font list, set by font loader, not this program
 }
 
 type fontInfoType struct {

--- a/template.go
+++ b/template.go
@@ -128,7 +128,7 @@ func (f *Fpdf) templateFontCatalog() {
 	}
 	for _, key = range keyList {
 		font = f.fonts[key]
-		f.outf("/F%d %d 0 R", font.I, font.N)
+		f.outf("/F%s %d 0 R", font.i, font.N)
 	}
 	f.out(">>")
 }


### PR DESCRIPTION
Made font id a string which is a sha1 sum of the contents of the json file.