### PR TITLE
Fix right alignment

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2441,7 +2441,7 @@ func (f *Fpdf) WriteAligned(width, lineHeight float64, textStr, alignStr string)
 			f.Write(lineHeight, lineStr)
 			f.SetLeftMargin(lMargin)
 		case "R":
-			f.SetLeftMargin(lMargin + (width - lineWidth) - rMargin)
+			f.SetLeftMargin(lMargin + (width - lineWidth))
 			f.Write(lineHeight, lineStr)
 			f.SetLeftMargin(lMargin)
 		default:


### PR DESCRIPTION
width has already been reduced by left and right margin, so right margin doesn't need to be subtracted twice