### PR TITLE
Add SetFontStyle method

### DIFF
--- a/def.go
+++ b/def.go
@@ -426,6 +426,7 @@ type Pdf interface {
 	SetFontLoader(loader FontLoader)
 	SetFontLocation(fontDirStr string)
 	SetFontSize(size float64)
+	SetFontStyle(styleStr string)
 	SetFontUnitSize(size float64)
 	SetFooterFunc(fnc func())
 	SetFooterFuncLpi(fnc func(lastPage bool))

--- a/fpdf.go
+++ b/fpdf.go
@@ -1799,6 +1799,11 @@ func (f *Fpdf) SetFont(familyStr, styleStr string, size float64) {
 	return
 }
 
+// SetFontStyle sets the style of the current font. See also SetFont()
+func (f *Fpdf) SetFontStyle(styleStr string) {
+	f.SetFont(f.fontFamily, styleStr, f.fontSizePt)
+}
+
 // SetFontSize defines the size of the current font. Size is specified in
 // points (1/ 72 inch). See also SetFontUnitSize().
 func (f *Fpdf) SetFontSize(size float64) {


### PR DESCRIPTION
Currently, to change just the font style in user code, you have to do something like this:

````
pdf.SetFont("", "B", 0)
````

Now you can do:
````
pdf.SetFontStyle("B")
````

This implementation simply calls the exported `SetFont()` method internally. This differs slightly to `SetFontSize()`, which updates internal state and writes to the PDF in its own method. Let me know if you have any preference, or if I've missed anything.

Thanks.