### PR TITLE
Add support for imported objects and templates for gofpdf v2

### DIFF
--- a/def.go
+++ b/def.go
@@ -504,6 +504,9 @@ type Fpdf struct {
 	offsets          []int                      // array of object offsets
 	templates        map[string]Template        // templates used in this document
 	templateObjects  map[string]int             // template object IDs within this document
+	importedObjs     map[string]string          // imported template objects (gofpdi)
+	importedTplObjs  map[string]string          // imported template names and IDs (hashed) (gofpdi)
+	importedTplIds   map[string]int             // imported template ids hash to object id int (gofpdi)
 	buffer           fmtBuffer                  // buffer holding in-memory PDF
 	pages            []*bytes.Buffer            // slice[page] of page content; 1-based
 	state            int                        // current document state

--- a/def.go
+++ b/def.go
@@ -504,7 +504,8 @@ type Fpdf struct {
 	offsets          []int                      // array of object offsets
 	templates        map[string]Template        // templates used in this document
 	templateObjects  map[string]int             // template object IDs within this document
-	importedObjs     map[string]string          // imported template objects (gofpdi)
+	importedObjs     map[string][]byte          // imported template objects (gofpdi)
+	importedObjPos   map[string]map[int]string  // imported template objects hashes and their positions (gofpdi)
 	importedTplObjs  map[string]string          // imported template names and IDs (hashed) (gofpdi)
 	importedTplIds   map[string]int             // imported template ids hash to object id int (gofpdi)
 	buffer           fmtBuffer                  // buffer holding in-memory PDF

--- a/fpdf.go
+++ b/fpdf.go
@@ -4268,7 +4268,7 @@ func (f *Fpdf) putxobjectdict() {
 }
 
 func (f *Fpdf) putresourcedict() {
-	f.out("/ProcSet [/PDF /Text /Image /ImageC /ImageI]")
+	f.out("/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]")
 	f.out("/Font <<")
 	{
 		var keyList []string

--- a/fpdf.go
+++ b/fpdf.go
@@ -549,7 +549,6 @@ func (f *Fpdf) SetDisplayMode(zoomStr, layoutStr string) {
 // by default.
 func SetDefaultCompression(compress bool) {
 	gl.noCompress = !compress
-	gl.noCompress = false
 }
 
 // SetCompression activates or deactivates page compression with zlib. When
@@ -3753,7 +3752,7 @@ func (f *Fpdf) putpages() {
 		f.out("endobj")
 		// Page content
 		f.newobj()
-		if f.compress && false {
+		if f.compress {
 			data := sliceCompress(f.pages[n].Bytes())
 			f.outf("<</Filter /FlateDecode /Length %d>>", len(data))
 			f.putstream(data)

--- a/fpdf.go
+++ b/fpdf.go
@@ -3102,11 +3102,6 @@ func (f *Fpdf) GetImageInfo(imageStr string) (info *ImageInfoType) {
 	return f.images[imageStr]
 }
 
-// Get the next object ID so that gofpdi knows where to start the object IDs
-func (f *Fpdf) GetNextObjectID() int {
-	return f.n + 2
-}
-
 // Import objects from gofpdi into current document
 func (f *Fpdf) ImportObjects(objs map[string][]byte) {
 	for k, v := range objs {


### PR DESCRIPTION
This allows v2 of gofpdf to use gofpdi free pdf document importer.  The code that calls gofpdi is in the jung-kurt/gofpdfcontrib repository.