### PR TITLE
Fix for not concating already defined filepath

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -1601,6 +1601,7 @@ func (f *Fpdf) addFont(familyStr, styleStr, fileStr string, isUTF8 bool) {
 		}
 		var ttfStat os.FileInfo
 		var err error
+		fileStr = path.Join(f.fontpath, fileStr)
 		ttfStat, err = os.Stat(fileStr)
 		if err != nil {
 			f.SetError(err)


### PR DESCRIPTION
With recent utf-8 support it is somewhat forgotten to add already defined font base dir. This fix is not backward compatible with already committed code in master.

	pdf := gofpdf.NewCustom(&gofpdf.InitType{
		UnitStr: "mm",
		Size: gofpdf.SizeType{
			Wd: 100,
			Ht: 62,
		},
		FontDirStr: "./gofpdf/font",
	})
	pdf.AddUTF8Font("TimesNewRoman", "", "Times_New_Roman.ttf")
	pdf.AddUTF8Font("TimesNewRoman", "B", "Times_New_Roman_Bold.ttf")
	pdf.AddUTF8Font("TimesNewRoman", "I", "Times_New_Roman_Italic.ttf")
	pdf.AddUTF8Font("TimesNewRoman", "BI", "Times_New_Roman_Bold_Italic.ttf")`

The code above didn't load fonts properly but with this fix code above will work.