### PR TITLE
maintain precision of desired w & h of barcodes

### DIFF
--- a/contrib/barcode/barcode.go
+++ b/contrib/barcode/barcode.go
@@ -93,13 +93,17 @@ func printBarcode(pdf barcodePdf, code string, x, y float64, w, h *float64, flow
 		}
 	}
 
+	scaleToWidthF := float64(scaleToWidth)
+	scaleToHeightF := float64(scaleToHeight)
+
 	if w != nil {
-		scaleToWidth = int(*w)
+		scaleToWidthF = *w
 	}
 	if h != nil {
-		scaleToHeight = int(*h)
+		scaleToHeightF = *h
 	}
-	pdf.Image(bname, x, y, float64(scaleToWidth), float64(scaleToHeight), flow, "jpg", 0, "")
+
+	pdf.Image(bname, x, y, scaleToWidthF, scaleToHeightF, flow, "jpg", 0, "")
 
 }
 

--- a/contrib/barcode/barcode_test.go
+++ b/contrib/barcode/barcode_test.go
@@ -199,3 +199,24 @@ func TestGetUnscaledBarcodeDimensions(t *testing.T) {
 	// Output:
 	// Successfully generated ../../pdf/contrib_barcode_GetBarcodeDimensions.pdf
 }
+
+// TestBarcodeNonIntegerScalingFactors shows that the barcode may be scaled to non-integer sizes
+func TestBarcodeNonIntegerScalingFactors(t *testing.T) {
+	pdf := gofpdf.New("L", "in", "A4", "")
+	pdf.SetFont("Helvetica", "", 12)
+	pdf.SetFillColor(200, 200, 220)
+	pdf.AddPage()
+
+	key := barcode.RegisterQR(pdf, "qrcode", qr.H, qr.Unicode)
+	var scale float64 = 1.5
+	barcode.BarcodeUnscalable(pdf, key, 0.5, 0.5, &scale, &scale, false)
+
+	pdf.SetDrawColor(255, 0, 0)
+	pdf.Line(0.5, 0.5, 0.5+scale, 0.5+scale)
+
+	fileStr := example.Filename("contrib_barcode_BarcodeScaling")
+	err := pdf.OutputFileAndClose(fileStr)
+	example.Summary(err, fileStr)
+	// Output:
+	// Successfully generated ../../pdf/contrib_barcode_BarcodeScaling.pdf
+}


### PR DESCRIPTION
This fixes an issue with barcode scaling that limited
barcode sizes to integer multiples of the pdf's unit.