### PR TITLE
Improve write performance

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2537,7 +2537,7 @@ func (f *Fpdf) MultiCell(w, h float64, txtStr, borderStr, alignStr string, fill 
 		if f.isCurrentUTF8 {
 			c = []rune(s)[i]
 		} else {
-			c = rune([]byte(s)[i])
+			c = rune(byte(s[i]))
 		}
 		if c == '\n' {
 			// Explicit line break
@@ -2674,7 +2674,7 @@ func (f *Fpdf) write(h float64, txtStr string, link int, linkStr string) {
 		if f.isCurrentUTF8 {
 			c = []rune(s)[i]
 		} else {
-			c = rune([]byte(s)[i])
+			c = rune(byte(s[i]))
 		}
 		if c == '\n' {
 			// Explicit line break

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.12
 
 require (
 	github.com/boombuler/barcode v1.0.0
+	github.com/phpdave11/gofpdi v1.0.3
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58
 	golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec
 )
+
+replace github.com/jung-kurt/gopdf => ./

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,10 @@
-github.com/boombuler/barcode v1.0.0 h1:s1TvRnXwL2xJRaccrdcBQMZxq6X7DvsMogtmJeHDdrc=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/phpdave11/gofpdi v1.0.3/go.mod h1:B7ryN7q4MLItB8BDM5PJAplblJegAAcaI98viOZUihg=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58 h1:nlG4Wa5+minh3S9LVFtNoY+GVRiudA2e3EVfcCi3RCA=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec h1:arXJwtMuk5vqI1NHX0UTnNw977rYk5Sl4jQqHj+hun4=
 golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Remove an unnecessary array copy. Improves performance from O(n^2) to O(n).

This assumes that each byte corresponds 1-1 to a rune.