### PR TITLE
fix utf8 text wrapping

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2800,8 +2800,8 @@ func (f *Fpdf) WriteLinkID(h float64, displayStr string, linkID int) {
 func (f *Fpdf) WriteAligned(width, lineHeight float64, textStr, alignStr string) {
 	lMargin, _, rMargin, _ := f.GetMargins()
 
+	pageWidth, _ := f.GetPageSize()
 	if width == 0 {
-		pageWidth, _ := f.GetPageSize()
 		width = pageWidth - (lMargin + rMargin)
 	}
 
@@ -2819,6 +2819,7 @@ func (f *Fpdf) WriteAligned(width, lineHeight float64, textStr, alignStr string)
 		lineStr := string(lineBt)
 		lineWidth := f.GetStringWidth(lineStr)
 
+		f.SetLeftMargin(lMargin + (width - lineWidth) - 2.01*f.cMargin)
 		switch alignStr {
 		case "C":
 			f.SetLeftMargin(lMargin + ((width - lineWidth) / 2))
@@ -2831,6 +2832,7 @@ func (f *Fpdf) WriteAligned(width, lineHeight float64, textStr, alignStr string)
 		default:
 			f.Write(lineHeight, lineStr)
 		}
+		f.SetRightMargin(rMargin)
 	}
 }
 


### PR DESCRIPTION
UTF8 text splitted correctly by SplitText function in WriteAligned
method:

https://github.com/jung-kurt/gofpdf/blob/3aaf0b1a66c0ab02d925917376898a5856061d59/fpdf.go#L2811

Then, lines of text are written via Write function, and if text is
already wrapped by given width it will be printed using 'last chunk' case:

https://github.com/jung-kurt/gofpdf/blob/3aaf0b1a66c0ab02d925917376898a5856061d59/fpdf.go#L2747-L2754

But in this case, gofpdf does not move cursor to the next cell, which
cause all text to be printed on the same line without actual wrapping.

This commit makes workaround for it by explicitly setting right margin
to force automatic line break case:

https://github.com/jung-kurt/gofpdf/blob/3aaf0b1a66c0ab02d925917376898a5856061d59/fpdf.go#L2705-L2706