### PR TITLE
update contrib/gofpdi from v1.0.3 to v1.0.7

### DIFF
--- a/contrib/gofpdi/gofpdi.go
+++ b/contrib/gofpdi/gofpdi.go
@@ -2,6 +2,7 @@ package gofpdi
 
 import (
 	realgofpdi "github.com/phpdave11/gofpdi"
+	"io"
 )
 
 // Create new gofpdi instance
@@ -23,7 +24,21 @@ type gofpdiPdf interface {
 func ImportPage(f gofpdiPdf, sourceFile string, pageno int, box string) int {
 	// Set source file for fpdi
 	fpdi.SetSourceFile(sourceFile)
+	// return template id
+	return getTemplateID(f, pageno, box)
+}
 
+// ImportPage imports a page of a PDF with the specified box (/MediaBox,
+// /TrimBox, /ArtBox, /CropBox, or /BleedBox). Returns a template id that can
+// be used with UseImportedTemplate to draw the template onto the page.
+func ImportPageFromStream(f gofpdiPdf, rs *io.ReadSeeker, pageno int, box string) int {
+	// Set source stream for fpdi
+	fpdi.SetSourceStream(rs)
+	// return template id
+	return getTemplateID(f, pageno, box)
+}
+
+func getTemplateID(f gofpdiPdf, pageno int, box string) int {
 	// Import page
 	tpl := fpdi.ImportPage(pageno, box)
 
@@ -60,4 +75,13 @@ func UseImportedTemplate(f gofpdiPdf, tplid int, x float64, y float64, w float64
 	tplName, scaleX, scaleY, tX, tY := fpdi.UseTemplate(tplid, x, y, w, h)
 
 	f.UseImportedTemplate(tplName, scaleX, scaleY, tX, tY)
+}
+
+// GetPageSizes returns page dimensions for all pages of the imported pdf.
+// Result consists of map[<page number>]map[<box>]map[<dimension>]<value>.
+// <page number>: page number, note that page numbers start at 1
+// <box>: box identifier, e.g. "/MediaBox"
+// <dimension>: dimension string, either "w" or "h"
+func GetPageSizes() map[int]map[string]map[string]float64 {
+	return fpdi.GetPageSizes()
 }

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.12
 
 require (
 	github.com/boombuler/barcode v1.0.0
-	github.com/phpdave11/gofpdi v1.0.3
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/phpdave11/gofpdi v1.0.7
 	github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58
 	golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,9 @@ github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/phpdave11/gofpdi v1.0.3/go.mod h1:B7ryN7q4MLItB8BDM5PJAplblJegAAcaI98viOZUihg=
+github.com/phpdave11/gofpdi v1.0.7 h1:k2oy4yhkQopCK+qW8KjCla0iU2RpDow+QUDmH9DDt44=
+github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=


### PR DESCRIPTION
Updates contrib/gofpdi from v1.0.3 to v1.0.7
* imports pdf documents from any io.ReadSeeker
* exposes page sizes of imported pdf documents

@phpdave11 Thanks again for your quick release. I hope this PR meets with your approval.