### PR TITLE
fix split line bug

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2551,20 +2551,23 @@ func (f *Fpdf) MultiCell(w, h float64, txtStr, borderStr, alignStr string, fill 
 	}
 	wmax := int(math.Ceil((w - 2*f.cMargin) * 1000 / f.fontSize))
 	s := strings.Replace(txtStr, "\r", "", -1)
+	srune := []rune(s)
 
+	// remove extra line breaks
 	var nb int
 	if f.isCurrentUTF8 {
-		nb = len([]rune(s))
-		for nb > 0 && []rune(s)[nb-1] == '\n' {
+		nb = len(srune)
+		for nb > 0 && srune[nb-1] == '\n' {
 			nb--
-			s = string([]rune(s)[0:nb])
 		}
+		srune = srune[0:nb]
 	} else {
 		nb = len(s)
-		if nb > 0 && []byte(s)[nb-1] == '\n' {
+		bytes2 := []byte(s)
+		for nb > 0 && bytes2[nb-1] == '\n' {
 			nb--
-			s = s[0:nb]
 		}
+		s = s[0:nb]
 	}
 	// dbg("[%s]\n", s)
 	var b, b2 string
@@ -2603,7 +2606,7 @@ func (f *Fpdf) MultiCell(w, h float64, txtStr, borderStr, alignStr string, fill 
 		if f.isCurrentUTF8 {
 			c = srune[i]
 		} else {
-			c = rune(byte(s[i]))
+			c = rune(s[i])
 		}
 		if c == '\n' {
 			// Explicit line break
@@ -2636,7 +2639,7 @@ func (f *Fpdf) MultiCell(w, h float64, txtStr, borderStr, alignStr string, fill 
 			}
 			continue
 		}
-		if c == ' ' {
+		if c == ' ' || isChinese(c) {
 			sep = i
 			ls = l
 			ns++

--- a/fpdf.go
+++ b/fpdf.go
@@ -2599,7 +2599,6 @@ func (f *Fpdf) MultiCell(w, h float64, txtStr, borderStr, alignStr string, fill 
 	ls := 0
 	ns := 0
 	nl := 1
-	srune := []rune(s)
 	for i < nb {
 		// Get next character
 		var c rune

--- a/splittext.go
+++ b/splittext.go
@@ -26,8 +26,7 @@ func (f *Fpdf) SplitText(txt string, w float64) (lines []string) {
 	for i < nb {
 		c := s[i]
 		l += cw[c]
-		if unicode.IsSpace(c) {
-			// if c == ' ' || c == '\t' || c == '\n' {
+		if unicode.IsSpace(c) || isChinese(c) {
 			sep = i
 		}
 		if c == '\n' || l > wmax {

--- a/util.go
+++ b/util.go
@@ -444,3 +444,11 @@ func remove(arr []int, key int) []int {
 	}
 	return append(arr[:n], arr[n+1:]...)
 }
+
+func isChinese(rune2 rune) bool {
+	// chinese unicode: 4e00-9fa5
+	if rune2 >= rune(0x4e00) && rune2 <= rune(0x9fa5) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
In English, a word should not be split into two lines, but Chinese words can be made into two lines.
I fixed this Bug mentioned in [issue](https://github.com/jung-kurt/gofpdf/issues/276).