### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ doc/body.md
 doc/index.html
 doc/index.html.ok
 coverage.html
+
+# macOS
+.DS_Store


### PR DESCRIPTION
It's a macOS folder view settings file commonly ignored in opensource projects.