### PR TITLE
Prevent image duplication

### DIFF
--- a/def.go
+++ b/def.go
@@ -165,20 +165,20 @@ func (p PointType) XY() (float64, float64) {
 // Changes to this structure should be reflected in its GobEncode and GobDecode
 // methods.
 type ImageInfoType struct {
-	data  []byte
-	smask []byte
-	n     int
-	w     float64
-	h     float64
-	cs    string
-	pal   []byte
-	bpc   int
-	f     string
-	dp    string
-	trns  []int
-	scale float64 // document scaling factor
-	dpi   float64
-	i     string
+	data  []byte  // Raw image data
+	smask []byte  // Soft Mask, an 8bit per-pixel transparency mask
+	n     int     // Image object number
+	w     float64 // Width
+	h     float64 // Height
+	cs    string  // Color space
+	pal   []byte  // Image color palette
+	bpc   int     // Bits Per Component
+	f     string  // Image filter
+	dp    string  // DecodeParms
+	trns  []int   // Transparency mask
+	scale float64 // Document scale factor
+	dpi   float64 // Dots-per-inch found from image file (png only)
+	i     string  // SHA-1 checksum of the above values.
 }
 
 func generateImageID(info *ImageInfoType) (string, error) {

--- a/fpdf.go
+++ b/fpdf.go
@@ -4244,11 +4244,31 @@ func (f *Fpdf) putimages() {
 	for key = range f.images {
 		keyList = append(keyList, key)
 	}
+
+	// Sort the keyList []string by the corrosponding image's width.
 	if f.catalogSort {
 		sort.SliceStable(keyList, func(i, j int) bool { return f.images[keyList[i]].w < f.images[keyList[j]].w })
 	}
+
+	// Maintain a list of inserted image SHA-1 hashes, with their
+	// corresponding object ID number.
+	insertedImages := map[string]int{}
+
 	for _, key = range keyList {
-		f.putimage(f.images[key])
+		image := f.images[key]
+
+		// Check if this image has already been inserted using it's SHA-1 hash.
+		insertedImageObjN, isFound := insertedImages[image.i]
+
+		// If found, skip inserting the image as a new object, and
+		// use the object ID from the insertedImages map.
+		// If not, insert the image into the PDF and store the object ID.
+		if isFound {
+			image.n = insertedImageObjN
+		} else {
+			f.putimage(image)
+			insertedImages[image.i] = image.n
+		}
 	}
 }
 

--- a/fpdf.go
+++ b/fpdf.go
@@ -4215,6 +4215,7 @@ func implode(sep string, arr []int) string {
 	return s.String()
 }
 
+// arrayCountValues counts the occurrences of each item in the $mp array.
 func arrayCountValues(mp []int) map[int]int {
 	answer := make(map[int]int)
 	for _, v := range mp {


### PR DESCRIPTION
Currently, it's possible to end up with the same image inserted into the final PDF multiple times. 

This is possible if you register the same image under two different keys (unlikely), but it's also possible when trying to use the same image in multiple templates. The [CreateTemplate example](https://github.com/jung-kurt/gofpdf/blob/5336f2c016d4b1b5e9399a84aa4657d374dd5cb3/fpdf_test.go#L2052) actually attempts this and the image is written into the PDF twice. After this  
change the filesize is reduced by about 20%.

It accomplishes this by storing the SHA-1 hash of each inserted image, and re-uses the objects ID if it's found. I've also committed my comments in a bunch of places from trying to understand the codebase.