### PR TITLE
 Initialize derived templates with parent images

### DIFF
--- a/def.go
+++ b/def.go
@@ -165,20 +165,20 @@ func (p PointType) XY() (float64, float64) {
 // Changes to this structure should be reflected in its GobEncode and GobDecode
 // methods.
 type ImageInfoType struct {
-	data  []byte
-	smask []byte
-	n     int
-	w     float64
-	h     float64
-	cs    string
-	pal   []byte
-	bpc   int
-	f     string
-	dp    string
-	trns  []int
-	scale float64 // document scaling factor
-	dpi   float64
-	i     string
+	data  []byte  // Raw image data
+	smask []byte  // Soft Mask, an 8bit per-pixel transparency mask
+	n     int     // Image object number
+	w     float64 // Width
+	h     float64 // Height
+	cs    string  // Color space
+	pal   []byte  // Image color palette
+	bpc   int     // Bits Per Component
+	f     string  // Image filter
+	dp    string  // DecodeParms
+	trns  []int   // Transparency mask
+	scale float64 // Document scale factor
+	dpi   float64 // Dots-per-inch found from image file (png only)
+	i     string  // SHA-1 checksum of the above values.
 }
 
 func generateImageID(info *ImageInfoType) (string, error) {

--- a/fpdf.go
+++ b/fpdf.go
@@ -4244,11 +4244,31 @@ func (f *Fpdf) putimages() {
 	for key = range f.images {
 		keyList = append(keyList, key)
 	}
+
+	// Sort the keyList []string by the corrosponding image's width.
 	if f.catalogSort {
 		sort.SliceStable(keyList, func(i, j int) bool { return f.images[keyList[i]].w < f.images[keyList[j]].w })
 	}
+
+	// Maintain a list of inserted image SHA-1 hashes, with their
+	// corresponding object ID number.
+	insertedImages := map[string]int{}
+
 	for _, key = range keyList {
-		f.putimage(f.images[key])
+		image := f.images[key]
+
+		// Check if this image has already been inserted using it's SHA-1 hash.
+		insertedImageObjN, isFound := insertedImages[image.i]
+
+		// If found, skip inserting the image as a new object, and
+		// use the object ID from the insertedImages map.
+		// If not, insert the image into the PDF and store the object ID.
+		if isFound {
+			image.n = insertedImageObjN
+		} else {
+			f.putimage(image)
+			insertedImages[image.i] = image.n
+		}
 	}
 }
 

--- a/fpdf.go
+++ b/fpdf.go
@@ -4215,6 +4215,7 @@ func implode(sep string, arr []int) string {
 	return s.String()
 }
 
+// arrayCountValues counts the occurrences of each item in the $mp array.
 func arrayCountValues(mp []int) map[int]int {
 	answer := make(map[int]int)
 	for _, v := range mp {

--- a/template.go
+++ b/template.go
@@ -84,7 +84,18 @@ func (f *Fpdf) UseTemplateScaled(t Template, corner PointType, size SizeType) {
 	for _, tt := range t.Templates() {
 		f.templates[tt.ID()] = tt
 	}
+
+	// Create a list of existing image SHA-1 hashes.
+	existingImages := map[string]bool{}
+	for _, image := range f.images {
+		existingImages[image.i] = true
+	}
+
+	// Add each template image to $f, unless already present.
 	for name, ti := range t.Images() {
+		if _, found := existingImages[ti.i]; found {
+			continue
+		}
 		name = sprintf("t%s-%s", t.ID(), name)
 		f.images[name] = ti
 	}

--- a/template_impl.go
+++ b/template_impl.go
@@ -296,4 +296,8 @@ func (t *Tpl) loadParamsFromFpdf(f *Fpdf) {
 	t.Fpdf.fontSizePt = f.fontSizePt
 	t.Fpdf.fontStyle = f.fontStyle
 	t.Fpdf.ws = f.ws
+
+	for key, value := range f.images {
+		t.Fpdf.images[key] = value
+	}
 }


### PR DESCRIPTION
(Based upon #296, please review that one first!)

This allows templates derived from the principal struct (`pdf.UseTemplate()` or `pdf.UseTemplateScaled()`) to inherit the parents images list. They'll be available using the same key to facilitate image re-use.

As inheritance happens with the loaded fonts and [many other settings](https://github.com/jung-kurt/gofpdf/blob/ced1e15bca902f15732b6380aaa4bdc419d87eac/template_impl.go#L278), I think images would be expected too. Due to my other PR, this shouldn't increase the final PDF size.

This one however is a ⚠️ **breaking change** ⚠️. Consider the following scenario...

1. An image is registered in the main pdf `pdf.RegisterImageReader("myKey" ...)`
2. A new template is derived using `pdf.CreateTemplate()`
3. An image being registered in the template `tpl.RegisterImageReader("myKey" ...)`

Due to the new template inheriting images, step 3 will [silently fail](https://github.com/jung-kurt/gofpdf/blob/ced1e15bca902f15732b6380aaa4bdc419d87eac/fpdf.go#L3101) due to an image already being registered with that key.

It is quite an obscure scenario, but it's best to consider it. I'm not sure how breaking changes are managed in this library (Is that what the v2 branch is for?)

Thanks :)