### PR TITLE
Add UTF16 support to RegisterAlias

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -3780,6 +3780,10 @@ func (f *Fpdf) SetJavascript(script string) {
 // document is closed.
 func (f *Fpdf) RegisterAlias(alias, replacement string) {
 	f.aliasMap[alias] = replacement
+	// Add a UTF16 mapping
+	aliasUtf16 := utf8toutf16(f.aliasNbPagesStr, false)
+	replacementUtf16 := utf8toutf16(replacement, false)
+	f.aliasMap[aliasUtf16] = replacementUtf16
 }
 
 func (f *Fpdf) replaceAliases() {
@@ -3803,9 +3807,6 @@ func (f *Fpdf) putpages() {
 	nb := f.page
 	if len(f.aliasNbPagesStr) > 0 {
 		// Replace number of pages
-		alias := utf8toutf16(f.aliasNbPagesStr, false)
-		r := utf8toutf16(sprintf("%d", nb), false)
-		f.RegisterAlias(alias, r)
 		f.RegisterAlias(f.aliasNbPagesStr, sprintf("%d", nb))
 	}
 	f.replaceAliases()

--- a/fpdf.go
+++ b/fpdf.go
@@ -3781,7 +3781,7 @@ func (f *Fpdf) SetJavascript(script string) {
 func (f *Fpdf) RegisterAlias(alias, replacement string) {
 	f.aliasMap[alias] = replacement
 	// Add a UTF16 mapping
-	aliasUtf16 := utf8toutf16(f.aliasNbPagesStr, false)
+	aliasUtf16 := utf8toutf16(alias, false)
 	replacementUtf16 := utf8toutf16(replacement, false)
 	f.aliasMap[aliasUtf16] = replacementUtf16
 }

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -2245,7 +2245,8 @@ func ExampleFpdf_AddSpotColor() {
 // contents.
 func ExampleFpdf_RegisterAlias() {
 	pdf := gofpdf.New("P", "mm", "A4", "")
-	pdf.SetFont("Arial", "", 12)
+	pdf.AddUTF8Font("dejavu", "BI", example.FontFile("DejaVuSansCondensed-BoldOblique.ttf"))
+	pdf.SetFont("dejavu", "BI", 12)
 	pdf.AddPage()
 
 	// Write the table of contents. We use aliases instead of the page number


### PR DESCRIPTION
Move the UTF16 conversion into RegisterAlias to allow external alias registration to support UTF16.