### PR TITLE
fix utf16 in bookmarks

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2183,6 +2183,9 @@ func (f *Fpdf) Bookmark(txtStr string, level int, y float64) {
 	if y == -1 {
 		y = f.y
 	}
+	if f.isCurrentUTF8 {
+		txtStr = utf8toutf16(txtStr)
+	}
 	f.outlines = append(f.outlines, outlineType{text: txtStr, level: level, y: y, p: f.PageNo(), prev: -1, last: -1, next: -1, first: -1})
 }
 


### PR DESCRIPTION
Fix for https://github.com/jung-kurt/gofpdf/issues/307

Tested on this code: 
```
	pdf := gofpdf.New("P", "mm", "A5", "")
	pdf.AddUTF8Font("HAN NOM A", "", "hn.ttf")
	pdf.SetFont("HAN NOM A", "", 16)
	pdf.AddPage()
	pdf.Bookmark("1段落", 1, -1)
	pdf.Cell(0, 6, "2段落")
	pdf.Ln(50)
	pdf.AddPage()
	fileStr := example.Filename("Fpdf_Bookmark")
	err := pdf.OutputFileAndClose(fileStr)
	example.Summary(err, fileStr)
	// Output:
	// Successfully generated pdf/Fpdf_Bookmark.pdf

```
Result PDF:
![1569709835_0130_29092019_519x248](https://user-images.githubusercontent.com/15653599/65823106-c87ac800-e258-11e9-82cb-19ad16d410d8.png)

I was unable to find ttf version of the font in original issue so used different one, but I think it won't be a problem.
