### PR TITLE
Add SetTextRenderingMode function

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2226,6 +2226,20 @@ func (f *Fpdf) SetWordSpacing(space float64) {
 	f.out(sprintf("%.5f Tw", space*f.k))
 }
 
+// SetTextRenderingMode sets the rendering mode of following text.
+// The mode can be as follows:
+// 0: Fill text
+// 1: Stroke text
+// 2: Fill, then stroke text
+// 3: Neither fill nor stroke text (invisible)
+// 4: Fill text and add to path for clipping
+// 5: Stroke text and add to path for clipping
+// 6: Fills then stroke text and add to path for clipping
+// 7: Add text to path for clipping
+func (f *Fpdf) SetTextRenderingMode(mode int) {
+	f.out(sprintf("%d Tr", mode))
+}
+
 // SetAcceptPageBreakFunc allows the application to control where page breaks
 // occur.
 //


### PR DESCRIPTION
This follows section 9.3.6 of the PDF32000_2008 specification.

I use this to create "invisible" text for overlaying on images, to make searchable PDFs from OCR results.

I also made a variant branch of this with consts for the different possible modes, addtextrenderingmode-withconsts. I wasn't sure which would be a more fpdf way of doing it, so made both versions.