### PR TITLE
Issue316 copy changes

### DIFF
--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -2813,3 +2813,27 @@ func ExampleFpdf_SetTextRenderingMode() {
 	// Output:
 	// Successfully generated pdf/Fpdf_TextRenderingMode.pdf
 }
+
+// TestIssue0316 addresses issue 316 in which AddUTF8FromBytes modifies its argument
+// utf8bytes resulting in a panic if you generate two PDFs wih the "same" font bytes.
+func TestIssue0316(t *testing.T) {
+	pdf := gofpdf.New(gofpdf.OrientationPortrait, "mm", "A4", "")
+	pdf.AddPage()
+	fontBytes, _ := ioutil.ReadFile(example.FontFile("DejaVuSansCondensed.ttf"))
+	ofontBytes := append([]byte{}, fontBytes...)
+	pdf.AddUTF8FontFromBytes("dejavu", "", fontBytes)
+	pdf.SetFont("dejavu", "", 16)
+	pdf.Cell(40, 10, "Hello World!")
+	fileStr := example.Filename("TestIssue0316")
+	err := pdf.OutputFileAndClose(fileStr)
+	example.Summary(err, fileStr)
+	pdf.AddPage()
+	if len(fontBytes) != len(ofontBytes) {
+		t.Fatal("Font data length changed during pdf generation")
+	}
+	for i, v := range fontBytes {
+		if v != ofontBytes[i] {
+			t.Fatal("Font data changed during pdf generation")
+		}
+	}
+}

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -2828,12 +2828,7 @@ func TestIssue0316(t *testing.T) {
 	err := pdf.OutputFileAndClose(fileStr)
 	example.Summary(err, fileStr)
 	pdf.AddPage()
-	if len(fontBytes) != len(ofontBytes) {
-		t.Fatal("Font data length changed during pdf generation")
-	}
-	for i, v := range fontBytes {
-		if v != ofontBytes[i] {
-			t.Fatal("Font data changed during pdf generation")
-		}
+	if !bytes.Equal(fontBytes, ofontBytes) {
+		t.Fatal("Font data changed during pdf generation")
 	}
 }


### PR DESCRIPTION
This my `worsefix` branch renamed, after reflecting I believe this is the correct way to fix it as it removes any side effects from the `splice` and `assembleTables` functions in `utf8fontfile.go` in addition I added a test `TestIssue0316`, if you back out the previous fix by changing all instances of `ReadLikeCopy` to just `Read` you can see the test fails, if you return them or apply this branch then the test passes. 

I did go through and check for any other instances of append modifying the underlying arrays. There were a couple I thought might be an issue but once I sat down to inspect them I was able to confirm they were working only on new arrays.