### PR TITLE
Prevent panic on unsupported char for MultiCell

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2707,6 +2707,10 @@ func (f *Fpdf) MultiCell(w, h float64, txtStr, borderStr, alignStr string, fill 
 			ls = l
 			ns++
 		}
+		if int(c) >= len(cw) {
+			f.err = fmt.Errorf("character outside the supported range: %s", string(c))
+			return
+		}
 		if cw[int(c)] == 0 { //Marker width 0 used for missing symbols
 			l += f.currentFont.Desc.MissingWidth
 		} else if cw[int(c)] != 65535 { //Marker width 65535 used for zero width symbols

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -2833,6 +2833,25 @@ func TestIssue0316(t *testing.T) {
 	}
 }
 
+func TestMultiCellUnsupportedChar(t *testing.T) {
+	pdf := gofpdf.New("P", "mm", "A4", "")
+	pdf.AddPage()
+	fontBytes, _ := ioutil.ReadFile(example.FontFile("DejaVuSansCondensed.ttf"))
+	pdf.AddUTF8FontFromBytes("dejavu", "", fontBytes)
+	pdf.SetFont("dejavu", "", 16)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("unexpected panic: %v", r)
+		}
+	}()
+
+	pdf.MultiCell(0, 5, "😀", "", "", false)
+
+	fileStr := example.Filename("TestMultiCellUnsupportedChar")
+	pdf.OutputFileAndClose(fileStr)
+}
+
 // ExampleFpdf_SetTextRenderingMode demonstrates embedding files in PDFs,
 // at the top-level.
 func ExampleFpdf_SetAttachments() {


### PR DESCRIPTION
Currently if an unsupported char is inserted (like `😀`) the library panics.

I think it would be better to return an error.